### PR TITLE
Update ASTRO denoms

### DIFF
--- a/data/assets.json
+++ b/data/assets.json
@@ -710,10 +710,15 @@
         "pion-1": "ibc/EFB00E728F98F0C4BBE8CA362123ACAB466EDA2826DC6837E49F4C1902F21BBA"
       },
       "osmosis": {
-        "osmosis-1": "ibc/8410580A4F5421DFDBD888212624591E92A9E3B5C87D3C58913CE16ABD98B9B4"
+        "osmosis-1": "ibc/C25A2303FE24B922DAFFDCE377AC5A42E5EF746806D32E2ED4B610DE85C203F7",
       },
       "terra": {
-        "phoenix-1": "terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26"
+        "phoenix-1": "terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26",
+        "pisco-1": "terra167dsqkh2alurx997wmycw9ydkyu54gyswe3ygmrs4lwume3vmwks8ruqnv",
+      },
+      "sei": {
+        "atlantic-2": "ibc/4552BF8EE9C7AFD889CACF426F866350AAE28DC73507B1411972C8C1B9B38732",
+        "pacific-1": "ibc/0EC78B75D318EA0AAB6160A12AEE8F3C7FEA3CFEAD001A3B103E11914709F4CE"
       }
     },
     "logo": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/astro.png",


### PR DESCRIPTION
This PR changes ASTRO denom on Osmosis to canonical version governed by Astroport DAO.
Also adds missing astro denoms on sei and pisco-1.